### PR TITLE
Adding V8 Library to ubuntu dependency install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are having problems compiling make sure you've got the latest version of 
 
 __Ubuntu-Based / Debian:__
 ```bash
-sudo apt-get install cmake g++ gdb git libsdl2-dev zlib1g-dev liblua5.3 libxdo-dev patchelf
+sudo apt-get install cmake g++ gdb git libsdl2-dev zlib1g-dev liblua5.3 libxdo-dev patchelf libv8-dev
 ```
 __Arch:__
 ```bash


### PR DESCRIPTION
Adding `libv8-dev` to be installed in the ubuntu/debian dependency install example.

Attempting to build without the libv8-dev library results in a error.

```
v8.h: No such file or directory
#include <v8.h>
```